### PR TITLE
Use GOOGLE_APPLICATION_CREDENTIALS env var also.

### DIFF
--- a/profile.d/heroku-google-cloud.sh
+++ b/profile.d/heroku-google-cloud.sh
@@ -6,7 +6,8 @@ export PATH=/app/vendor/google-cloud-sdk/bin:$PATH
 if [ -z $GOOGLE_CREDENTIALS ]; then
     echo "GOOGLE_CREDENTIALS not set"
 else
-    echo "$GOOGLE_CREDENTIALS" | base64 -d > /app/google-credentials.json
+    export GOOGLE_APPLICATION_CREDENTIALS='/app/google-credentials.json'
+    echo "$GOOGLE_CREDENTIALS" | base64 -d > $GOOGLE_APPLICATION_CREDENTIALS
     gcloud auth activate-service-account --key-file /app/google-credentials.json
 fi
 

--- a/profile.d/heroku-google-cloud.sh
+++ b/profile.d/heroku-google-cloud.sh
@@ -3,7 +3,7 @@
 # Add gcloud to PATH
 export PATH=/app/vendor/google-cloud-sdk/bin:$PATH
 
-if [ -z $GOOGLE_CREDENTIALS ]; then
+if [ -z "$GOOGLE_CREDENTIALS" ]; then
     echo "GOOGLE_CREDENTIALS not set"
 else
     export GOOGLE_APPLICATION_CREDENTIALS='/app/google-credentials.json'


### PR DESCRIPTION
Based on https://cloud.google.com/docs/authentication/production this build pack should set both the env var AND call the service auth command for both the CLI and API clients to 'just work'.

I could see this being undesired if users set this environment variable elsewhere.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/convertelligence/heroku-buildpack-google-cloud/6)
<!-- Reviewable:end -->
